### PR TITLE
add wiki-link to IAT in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ D-score.
 
 # Statement of need 
 
-Despite the Implicit Association Test (IAT) is commonly used for the implicit assessment of different constructs, ranging from racial prejudice to brand preferences, there is not an open source and easy-to-use application for the computation of its effect, the so-called *D-score*. DscoreApp is meant to fill this gap and to provide users with a free and easy to use Shiny Web application for the computation of the IAT *D-score*.
+Despite the [Implicit Association Test (IAT)](https://en.wikipedia.org/wiki/Implicit-association_test) is commonly used for the implicit assessment of different constructs, ranging from racial prejudice to brand preferences, there is not an open source and easy-to-use application for the computation of its effect, the so-called *D-score*. DscoreApp is meant to fill this gap and to provide users with a free and easy to use Shiny Web application for the computation of the IAT *D-score*.
 
 # Installation instructions
 


### PR DESCRIPTION
This adds a link to the [wikipedia article on IAT](https://en.wikipedia.org/wiki/Implicit-association_test) to avoid people automatically switching off when they're unfamiliar with that term.